### PR TITLE
ローカルMCPサーバーとしての使用に対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,40 @@ SnowflakeデータベースとClaude（MCP対応クライアント）を安全�
 
 ## 🔧 インストール
 
-### 1. リポジトリのクローン
+### 方法1: グローバルインストール（推奨）
 
 ```bash
+# 1. リポジトリのクローン
 git clone <repository-url>
 cd snowflake-mcp-server
+
+# 2. グローバルインストール
+uv tool install .
+
+# 3. インストール確認
+snowflake-mcp-server --help
 ```
 
-### 2. 依存関係のインストール
+### 方法2: パッケージとしてインストール
 
 ```bash
+# 1. リポジトリのクローンとビルド
+git clone <repository-url>
+cd snowflake-mcp-server
+uv build
+
+# 2. 他のプロジェクトでインストール
+uv add ./dist/snowflake_mcp_server-0.1.0-py3-none-any.whl
+```
+
+### 方法3: 開発用セットアップ
+
+```bash
+# リポジトリのクローン
+git clone <repository-url>
+cd snowflake-mcp-server
+
+# 依存関係のインストール
 uv sync
 ```
 
@@ -86,11 +110,34 @@ export SNOWFLAKE_OAUTH_TOKEN="your-oauth-token"
 
 Claude Codeの設定ファイル（通常 `~/.claude.json`）を編集：
 
+#### グローバルインストール後の設定
+
 ```json
 {
   "mcpServers": {
     "snowflake-mcp": {
-      "command": "uv",
+      "command": "snowflake-mcp-server",
+      "env": {
+        "SNOWFLAKE_ACCOUNT": "your-account",
+        "SNOWFLAKE_USER": "your-username",
+        "SNOWFLAKE_DATABASE": "your-database",
+        "SNOWFLAKE_SCHEMA": "your-schema",
+        "SNOWFLAKE_WAREHOUSE": "your-warehouse",
+        "SNOWFLAKE_ROLE": "your-role",
+        "SNOWFLAKE_PRIVATE_KEY_PATH": "/path/to/rsa_key.p8"
+      }
+    }
+  }
+}
+```
+
+#### 開発用セットアップの設定
+
+```json
+{
+  "mcpServers": {
+    "snowflake-mcp": {
+      "command": "/path/to/uv",
       "args": ["run", "--frozen", "python", "-m", "snowflake_mcp"],
       "cwd": "/path/to/snowflake-mcp-server",
       "env": {
@@ -106,6 +153,8 @@ Claude Codeの設定ファイル（通常 `~/.claude.json`）を編集：
   }
 }
 ```
+
+**注意**: uvのパスを確認するには `which uv` を実行してください。
 
 ### 2. Claude Codeの再起動
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,16 @@ dependencies = [
     "snowflake-connector-python>=3.16.0",
 ]
 
+[project.scripts]
+snowflake-mcp-server = "snowflake_mcp.__main__:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/snowflake_mcp"]
+
 [dependency-groups]
 dev = [
     "anyio>=4.9.0",

--- a/src/snowflake_mcp/__main__.py
+++ b/src/snowflake_mcp/__main__.py
@@ -55,5 +55,9 @@ async def get_schema() -> List[Dict[str, Any]]:
     except Exception as e:
         raise RuntimeError(f"Failed to get schema: {str(e)}")
 
-if __name__ == "__main__":
+def main():
+    """Main entry point for the Snowflake MCP Server."""
     mcp.run()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要

  Snowflake MCP Serverをローカルで使用できるように、パッケージ化とドキュメ
  ント整備を行いました。
  ユーザーは開発環境だけでなく、グローバルインストールやパッケージインスト
  ールを通じて、
  他のプロジェクトでも簡単にSnowflake
  MCPサーバーを利用できるようになります。

  ## 変更内容

  ### パッケージ設定
  - `pyproject.toml`にエントリーポイント`snowflake-mcp-server`を追加
  - hatchlingを使用したビルドシステムの設定
  - wheel/tarballパッケージの生成に対応

  ### コード変更
  - `__main__.py`に`main()`関数を追加してCLI実行に対応
  - パッケージとして実行可能な構造に変更

  ### ドキュメント更新
  - `README.md`に3つのインストール方法を追加：
    1. グローバルインストール（`uv tool install`）
    2. パッケージインストール（wheel使用）
    3. 開発用セットアップ（既存方法）
  - Claude Codeでの設定例を両方のインストール方法に対応
  - uvのフルパス指定の注意点を追加