### PR TITLE
feat: SNOWFLAKE_ROLE環境変数の必須化とバリデーション強化

### DIFF
--- a/src/snowflake_mcp_server/connection.py
+++ b/src/snowflake_mcp_server/connection.py
@@ -35,8 +35,12 @@ def get_connection_params(env: EnvMapping | None = None) -> Dict[str, Any]:
         "account": env.get("SNOWFLAKE_ACCOUNT"),
         "user": env.get("SNOWFLAKE_USER"),
         "warehouse": env.get("SNOWFLAKE_WAREHOUSE"),
-        "role": env.get("SNOWFLAKE_ROLE"),  # セキュリティ上必須として扱う
+        "role": env.get("SNOWFLAKE_ROLE"),
     }
+
+    # "role" はセキュリティ上必須。未設定の場合は例外を投げる
+    if not params["role"]:
+        raise ValueError("セキュリティ上の理由により、SNOWFLAKE_ROLE 環境変数を設定する必要があります。")
 
     # データベースは任意なので、指定されている場合のみ追加
     database = env.get("SNOWFLAKE_DATABASE")


### PR DESCRIPTION
## Summary
- SNOWFLAKE_ROLE環境変数を必須パラメータとして厳格に扱うよう変更
- セキュリティ上の理由により、ROLEが未設定の場合はValueErrorを投げるバリデーションを追加
- 全テストケースを修正してROLE環境変数を含めるよう更新

## Test plan
- [x] 全48テストが正常に通ることを確認済み
- [x] ROLE未設定時のValueError例外処理が正しく動作することを確認
- [x] 既存の接続パラメータ生成ロジックが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)